### PR TITLE
JWT authentication

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11967,9 +11967,9 @@
       }
     },
     "stream-sea-client": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/stream-sea-client/-/stream-sea-client-3.0.0.tgz",
-      "integrity": "sha512-ktACjoIQn2ploexDY9R5duEgEb2zBpco5iCRF1hD2NNXYcR7UabugUta9I4QUkdn6PqISKsupyF872pbTUOqkg==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/stream-sea-client/-/stream-sea-client-3.1.0.tgz",
+      "integrity": "sha512-iLCV3Tla6A1IHa0bfhesgr6WksYEgD6lzpV/F70UtbZ+8qSF/4UR7jPqnpnFm2ULIvx6eR7x6X3WHR+AqOUq/Q==",
       "requires": {
         "@types/request-promise-native": "^1.0.17",
         "@types/ws": "^7.2.0",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "react-dom": "^16.12.0",
     "react-json-tree": "0.11.2",
     "react-scripts": "3.4.0",
-    "stream-sea-client": "3.0.0",
+    "stream-sea-client": "3.1.0",
     "styled-components": "5.0.1",
     "typescript": "3.7.5"
   },

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -5,18 +5,31 @@ import styled from 'styled-components';
 import JSONTree from 'react-json-tree';
 
 const subscribeToStreamSea = async (cb: (msg: any) => void) => {
-  const subscription = await streamSea.subscribe({
-    stream: process.env.REACT_APP_STREAM_NAME!,
-    clientId: process.env.REACT_APP_CLIENT_ID!,
-    clientSecret: process.env.REACT_APP_CLIENT_SECRET!,
-    remoteServerHost: process.env.REACT_APP_REMOTE_SERVER_HOST!,
-    remoteServerPort: process.env.REACT_APP_REMOTE_SERVER_PORT || '443',
-    secure: !!process.env.REACT_APP_SECURE,
-    fanout: true,
-  })
-  subscription.on('message', (msg:any) => {cb(msg)})
-  subscription.on('error', (err:any) => console.error(err))
-  subscription.on('close', () =>console.log('Connection closed'))
+  let subscription
+  if (process.env.REACT_APP_JWT){
+    subscription = await streamSea.subscribeWithJwt({
+      stream: process.env.REACT_APP_STREAM_NAME!,
+      clientId: process.env.REACT_APP_CLIENT_ID!,
+      jwt: process.env.REACT_APP_JWT!,
+      remoteServerHost: process.env.REACT_APP_REMOTE_SERVER_HOST!,
+      remoteServerPort: process.env.REACT_APP_REMOTE_SERVER_PORT || '443',
+      secure: !!process.env.REACT_APP_SECURE,
+      fanout: true,
+    })
+  } else {
+    subscription = await streamSea.subscribe({
+      stream: process.env.REACT_APP_STREAM_NAME!,
+      clientId: process.env.REACT_APP_CLIENT_ID!,
+      clientSecret: process.env.REACT_APP_CLIENT_SECRET!,
+      remoteServerHost: process.env.REACT_APP_REMOTE_SERVER_HOST!,
+      remoteServerPort: process.env.REACT_APP_REMOTE_SERVER_PORT || '443',
+      secure: !!process.env.REACT_APP_SECURE,
+      fanout: true,
+    })
+  }
+  subscription.on('message', (msg: any) => cb(msg))
+  subscription.on('error', (err: any) => console.error(err))
+  subscription.on('close', () => console.log('Connection closed'))
 }
 
 const AppContainer = styled.div`


### PR DESCRIPTION
Support JWT authentication

TODO: Link against stream-sea-client 3.1 when published

## Manual testing
- Link against stream-sea-client 3.1 (https://github.com/Portchain/stream-sea-client-node/pull/11)
- Verify you can subscribe to a stream with JWT authentication and receive messages